### PR TITLE
Update outdated Python versions for lambda

### DIFF
--- a/templates/kubernetes-cluster.template.yaml
+++ b/templates/kubernetes-cluster.template.yaml
@@ -714,7 +714,7 @@ Resources:
               cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)
               return token
       Handler: "index.handler"
-      Runtime: "python3.7"
+      Runtime: "python3.9"
       Timeout: 5
       Role: !GetAtt LambdaExecutionRole.Arn
 
@@ -1276,7 +1276,7 @@ Resources:
                     print(e)
                 cfnresponse.send(event, context, cfnresponse.FAILED, {})
       Handler: "index.lambda_handler"
-      Runtime: "python3.6"
+      Runtime: "python3.9"
       Timeout: 5
       Role: !GetAtt CleanupClusterInfoRole.Arn
 


### PR DESCRIPTION
CloudFormation template for existing VPCs references unsupported versions of python. This proposes updating the version to Python 3.9

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
